### PR TITLE
Fix for chars > 126

### DIFF
--- a/lib/jsmin.c.index.js
+++ b/lib/jsmin.c.index.js
@@ -99,7 +99,7 @@ function assertEqual(a, b) {
     function isAlphanum(c) {
         return ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
             (c >= 'A' && c <= 'Z') || c === '_' || c === '$' || c === '\\' ||
-            c > 126);
+            c.charCodeAt(0) > 126);
     }
 
 

--- a/tests/expected_files/extended.min.js
+++ b/tests/expected_files/extended.min.js
@@ -1,0 +1,2 @@
+
+(function(µ){var µlogged=µ('.jHeaderConnected');var ಠ_ಠ=42;}(jQuery));

--- a/tests/test_files/extended.js
+++ b/tests/test_files/extended.js
@@ -1,0 +1,5 @@
+// test to check that extended ascii will be managed correctly :
+(function(µ){
+	var µlogged = µ('.jHeaderConnected');
+	var ಠ_ಠ = 42;
+}(jQuery));


### PR DESCRIPTION
the way something like this :
var µlogged=µ('.jHeaderConnected');
won't minify to this :
varµlogged=µ('.jHeaderConnected');

it's probably a bug anyway a char will never be > 126 by itself