### PR TITLE
Fix crash in isAlphaNum when testing non-string value

### DIFF
--- a/lib/jsmin.c.index.js
+++ b/lib/jsmin.c.index.js
@@ -97,9 +97,9 @@ function assertEqual(a, b) {
     */
 
     function isAlphanum(c) {
-        return ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-            (c >= 'A' && c <= 'Z') || c === '_' || c === '$' || c === '\\' ||
-            c.charCodeAt(0) > 126);
+      return (c !== -1 && ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                           (c >= 'A' && c <= 'Z') || c === '_' || c === '$' || c === '\\' ||
+                           c.charCodeAt(0) > 126));
     }
 
 

--- a/tests/jsmin.test.js
+++ b/tests/jsmin.test.js
@@ -130,5 +130,10 @@ for (; i < len; i++) {
 // Assert that during the mapping we skipped at most once
 assert.ok(timesSkipped <= 1, 'During mapping, we skipped at most once');
 
+// Make sure it works when running off end of string
+assert.doesNotThrow(function () {
+  jsmin('{\n}\n')
+});
+
 // Log success when done
 console.log('Success!');


### PR DESCRIPTION
-1 is used for EOF, and it sometimes get tested for isAlphanum. This caused
an exception when calling c.charCodeAt.
Also added a test for it.
